### PR TITLE
[FEAT] 유저 인증 및 퀴즈 풀이 결과

### DIFF
--- a/src/main/java/com/example/csdaily/config/JwtConfig.java
+++ b/src/main/java/com/example/csdaily/config/JwtConfig.java
@@ -1,0 +1,34 @@
+package com.example.csdaily.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.example.csdaily.auth.service.AuthService;
+import com.example.csdaily.security.JwtTokenInterceptor;
+import com.example.csdaily.security.JwtTokenProvider;
+import com.example.csdaily.security.LoginUserArgumentResolver;
+import com.example.csdaily.user.repository.UserRepository;
+
+import lombok.AllArgsConstructor;
+
+@Configuration
+@AllArgsConstructor
+public class JwtConfig implements WebMvcConfigurer {
+	private final JwtTokenInterceptor jwtTokenInterceptor;
+	private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(jwtTokenInterceptor);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginUserArgumentResolver);
+	}
+}

--- a/src/main/java/com/example/csdaily/gpt/dto/response/GeneratedQuizDto.java
+++ b/src/main/java/com/example/csdaily/gpt/dto/response/GeneratedQuizDto.java
@@ -6,7 +6,7 @@ import java.util.List;
 import com.example.csdaily.quiz.entity.Quiz;
 import com.example.csdaily.quiz.entity.QuizDifficulty;
 
-public record GeneratedQuizDto(String difficulty, String content, String hint, List<GeneratedQuizChoiceDto> choices, String extra, String conclusion) {
+public record GeneratedQuizDto(String difficulty, String content, String hint, List<GeneratedQuizChoiceDto> choices, String extraInfo, String conclusion) {
 	public Quiz toQuiz() {
 		return Quiz
 			.builder()
@@ -14,6 +14,8 @@ public record GeneratedQuizDto(String difficulty, String content, String hint, L
 			.content(content)
 			.difficulty(QuizDifficulty.valueOf(difficulty.toUpperCase()))
 			.hint(hint)
+			.extraInfo(extraInfo)
+			.conclusion(conclusion)
 			.build();
 	}
 }

--- a/src/main/java/com/example/csdaily/quiz/annotation/LoginUser.java
+++ b/src/main/java/com/example/csdaily/quiz/annotation/LoginUser.java
@@ -1,0 +1,11 @@
+package com.example.csdaily.quiz.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/com/example/csdaily/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/csdaily/quiz/controller/QuizController.java
@@ -4,6 +4,7 @@ import com.example.csdaily.quiz.annotation.LoginUser;
 import com.example.csdaily.quiz.dto.request.UserAnswerDto;
 import com.example.csdaily.quiz.dto.response.QuizDto;
 import com.example.csdaily.quiz.dto.response.QuizResultDto;
+import com.example.csdaily.quiz.entity.UserAnswer;
 import com.example.csdaily.quiz.service.QuizService;
 import com.example.csdaily.user.entity.User;
 
@@ -26,6 +27,7 @@ public class QuizController {
 
     @PostMapping
     public ResponseEntity<List<QuizResultDto>> submitQuizChoices(@LoginUser User user, @RequestBody List<UserAnswerDto> userAnswerDtos) {
-        return ResponseEntity.ok(quizService.submitUserAnswer(user, userAnswerDtos));
+        List<UserAnswer> userAnswers = quizService.submitUserAnswer(user, userAnswerDtos);
+        return ResponseEntity.ok(userAnswers.stream().map(QuizResultDto::fromUserAnswer).toList());
     }
 }

--- a/src/main/java/com/example/csdaily/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/csdaily/quiz/controller/QuizController.java
@@ -1,10 +1,12 @@
 package com.example.csdaily.quiz.controller;
 
+import com.example.csdaily.quiz.annotation.LoginUser;
 import com.example.csdaily.quiz.dto.request.UserAnswerDto;
 import com.example.csdaily.quiz.dto.response.QuizDto;
 import com.example.csdaily.quiz.dto.response.QuizResultDto;
-import com.example.csdaily.quiz.entity.UserAnswer;
 import com.example.csdaily.quiz.service.QuizService;
+import com.example.csdaily.user.entity.User;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +25,7 @@ public class QuizController {
     }
 
     @PostMapping
-    public ResponseEntity<List<QuizResultDto>> submitQuizChoices(@RequestBody List<UserAnswerDto> userAnswerDtos) {
-        return ResponseEntity.ok(quizService.submitUserAnswer(userAnswerDtos));
+    public ResponseEntity<List<QuizResultDto>> submitQuizChoices(@LoginUser User user, @RequestBody List<UserAnswerDto> userAnswerDtos) {
+        return ResponseEntity.ok(quizService.submitUserAnswer(user, userAnswerDtos));
     }
 }

--- a/src/main/java/com/example/csdaily/quiz/dto/response/QuizChoiceDetailDto.java
+++ b/src/main/java/com/example/csdaily/quiz/dto/response/QuizChoiceDetailDto.java
@@ -1,0 +1,10 @@
+package com.example.csdaily.quiz.dto.response;
+
+import com.example.csdaily.quiz.entity.QuizChoice;
+
+public record QuizChoiceDetailDto(long id, int choiceNumber, boolean isCorrect, String content, String commentary) {
+	public static QuizChoiceDetailDto fromQuizChoice(QuizChoice quizChoice) {
+		return new QuizChoiceDetailDto(quizChoice.getId(), quizChoice.getChoiceNumber(), quizChoice.isCorrect(),
+			quizChoice.getContent(), quizChoice.getCommentary());
+	}
+}

--- a/src/main/java/com/example/csdaily/quiz/dto/response/QuizResultDto.java
+++ b/src/main/java/com/example/csdaily/quiz/dto/response/QuizResultDto.java
@@ -1,4 +1,21 @@
 package com.example.csdaily.quiz.dto.response;
 
-public record QuizResultDto(long id, boolean isSolved) {
+import java.util.List;
+
+import com.example.csdaily.quiz.entity.Quiz;
+import com.example.csdaily.quiz.entity.UserAnswer;
+
+public record QuizResultDto(long id, boolean isSolved, List<QuizChoiceDetailDto> quizChoiceDetailDtos,
+							String extraInfo, String conclusion) {
+	public static QuizResultDto fromUserAnswer(UserAnswer userAnswer) {
+		boolean isSolved = userAnswer.getChoice().getIsCorrect();
+		Quiz quiz = userAnswer.getQuiz();
+		List<QuizChoiceDetailDto> quizChoiceDetailDtos = quiz.getChoices()
+			.stream()
+			.map(QuizChoiceDetailDto::fromQuizChoice)
+			.toList();
+
+		return new QuizResultDto(userAnswer.getId(), isSolved, quizChoiceDetailDtos, quiz.getExtraInfo(),
+			quiz.getConclusion());
+	}
 }

--- a/src/main/java/com/example/csdaily/quiz/entity/Quiz.java
+++ b/src/main/java/com/example/csdaily/quiz/entity/Quiz.java
@@ -30,6 +30,12 @@ public class Quiz {
     @Column
     private String hint;
 
+    @Column
+    private String extraInfo;
+
+    @Column
+    private String conclusion;
+
     @Column(name="difficulty")
     @Convert(converter= QuizDifficultyConverter.class)
     private QuizDifficulty difficulty;

--- a/src/main/java/com/example/csdaily/quiz/entity/UserAnswer.java
+++ b/src/main/java/com/example/csdaily/quiz/entity/UserAnswer.java
@@ -27,6 +27,6 @@ public class UserAnswer {
     private Quiz quiz;
 
     @JoinColumn
-    @OneToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.EAGER)
     private QuizChoice choice;
 }

--- a/src/main/java/com/example/csdaily/quiz/service/QuizService.java
+++ b/src/main/java/com/example/csdaily/quiz/service/QuizService.java
@@ -22,8 +22,6 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class QuizService {
-
-	private final UserRepository userRepository;
 	private final QuizRepository quizRepository;
 	private final UserAnswerRepository userAnswerRepository;
 
@@ -35,28 +33,23 @@ public class QuizService {
 		return quizRepository.findAllInCreatedAtEquals(LocalDate.now());
 	}
 
-	public List<QuizResultDto> submitUserAnswer(List<UserAnswerDto> userAnswerDtos) {
+	public List<QuizResultDto> submitUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
 		updateQuizMapAndQuizChoiceMapForToday();
-		List<UserAnswer> savedUserAnswers = saveUserAnswer(userAnswerDtos);
+		List<UserAnswer> savedUserAnswers = saveUserAnswer(user, userAnswerDtos);
 		return checkUserAnswerCorrectness(savedUserAnswers);
 	}
 
-	public List<UserAnswer> saveUserAnswer(List<UserAnswerDto> userAnswerDtos) {
-		// todo: 로그인한 유저 정보 획득 필요함. 현재는 mock 객체를 만들어 사용함.
-		User user = userRepository.findByKakaoId("kakao").get();
-
+	public List<UserAnswer> saveUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
 		if (userAnswerRepository.existsByQuizEqualsCreatedAtToToday(user, LocalDate.now())) {
 			// todo: 적절한 예외 클래스 필요
 			throw new RuntimeException("이미 문제를 풀었습니다!");
 		}
 
-		List<UserAnswer> userAnswers = userAnswerDtos.stream()
-			.map(userAnswerDto -> {
-				Quiz quiz = quizMap.get(userAnswerDto.quizId());
-				QuizChoice quizChoice = quizChoiceMap.get(userAnswerDto.quizChoiceId());
-				return userAnswerDto.toUserAnswer(user, quiz, quizChoice);
-			})
-			.toList();
+		List<UserAnswer> userAnswers = userAnswerDtos.stream().map(userAnswerDto -> {
+			Quiz quiz = quizMap.get(userAnswerDto.quizId());
+			QuizChoice quizChoice = quizChoiceMap.get(userAnswerDto.quizChoiceId());
+			return userAnswerDto.toUserAnswer(user, quiz, quizChoice);
+		}).toList();
 
 		return userAnswerRepository.saveAll(userAnswers);
 	}
@@ -76,7 +69,8 @@ public class QuizService {
 	}
 
 	public List<QuizResultDto> checkUserAnswerCorrectness(List<UserAnswer> userAnswers) {
-		return userAnswers.stream().map(userAnswer -> new QuizResultDto(
-			userAnswer.getQuiz().getId(), userAnswer.getChoice().isCorrect())).toList();
+		return userAnswers.stream()
+			.map(userAnswer -> new QuizResultDto(userAnswer.getQuiz().getId(), userAnswer.getChoice().isCorrect()))
+			.toList();
 	}
 }

--- a/src/main/java/com/example/csdaily/quiz/service/QuizService.java
+++ b/src/main/java/com/example/csdaily/quiz/service/QuizService.java
@@ -33,25 +33,13 @@ public class QuizService {
 		return quizRepository.findAllInCreatedAtEquals(LocalDate.now());
 	}
 
-	public List<QuizResultDto> submitUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
+	public List<UserAnswer> submitUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
 		updateQuizMapAndQuizChoiceMapForToday();
-		List<UserAnswer> savedUserAnswers = saveUserAnswer(user, userAnswerDtos);
-		return checkUserAnswerCorrectness(savedUserAnswers);
-	}
-
-	public List<UserAnswer> saveUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
 		if (userAnswerRepository.existsByQuizEqualsCreatedAtToToday(user, LocalDate.now())) {
 			// todo: 적절한 예외 클래스 필요
 			throw new RuntimeException("이미 문제를 풀었습니다!");
 		}
-
-		List<UserAnswer> userAnswers = userAnswerDtos.stream().map(userAnswerDto -> {
-			Quiz quiz = quizMap.get(userAnswerDto.quizId());
-			QuizChoice quizChoice = quizChoiceMap.get(userAnswerDto.quizChoiceId());
-			return userAnswerDto.toUserAnswer(user, quiz, quizChoice);
-		}).toList();
-
-		return userAnswerRepository.saveAll(userAnswers);
+		return saveUserAnswer(user, userAnswerDtos);
 	}
 
 	private void updateQuizMapAndQuizChoiceMapForToday() {
@@ -68,9 +56,13 @@ public class QuizService {
 		}
 	}
 
-	public List<QuizResultDto> checkUserAnswerCorrectness(List<UserAnswer> userAnswers) {
-		return userAnswers.stream()
-			.map(userAnswer -> new QuizResultDto(userAnswer.getQuiz().getId(), userAnswer.getChoice().isCorrect()))
-			.toList();
+	public List<UserAnswer> saveUserAnswer(User user, List<UserAnswerDto> userAnswerDtos) {
+		List<UserAnswer> userAnswers = userAnswerDtos.stream().map(userAnswerDto -> {
+			Quiz quiz = quizMap.get(userAnswerDto.quizId());
+			QuizChoice quizChoice = quizChoiceMap.get(userAnswerDto.quizChoiceId());
+			return userAnswerDto.toUserAnswer(user, quiz, quizChoice);
+		}).toList();
+
+		return userAnswerRepository.saveAll(userAnswers);
 	}
 }

--- a/src/main/java/com/example/csdaily/security/JwtTokenInterceptor.java
+++ b/src/main/java/com/example/csdaily/security/JwtTokenInterceptor.java
@@ -22,7 +22,13 @@ public class JwtTokenInterceptor implements HandlerInterceptor {
 	private final JwtTokenProvider jwtTokenProvider;
 
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-		String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+		String authorizationHeader = request.getHeader("Authorization");
+		if (authorizationHeader == null) {
+			request.setAttribute("user", null);
+			return true;
+		}
+
+		String accessToken = authorizationHeader.replace("Bearer ", "");
 		log.info("Access token : {}", accessToken);
 
 		Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);

--- a/src/main/java/com/example/csdaily/security/JwtTokenInterceptor.java
+++ b/src/main/java/com/example/csdaily/security/JwtTokenInterceptor.java
@@ -1,0 +1,35 @@
+package com.example.csdaily.security;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.example.csdaily.auth.service.AuthService;
+import com.example.csdaily.user.entity.User;
+import com.example.csdaily.user.repository.UserRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class JwtTokenInterceptor implements HandlerInterceptor {
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+		log.info("Access token : {}", accessToken);
+
+		Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
+		Optional<User> maybeUser = userRepository.findById(userId);
+		request.setAttribute("user", maybeUser);
+		log.info("User id in token : {}", maybeUser.orElse(null));
+
+		return true;
+	}
+}

--- a/src/main/java/com/example/csdaily/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/csdaily/security/JwtTokenProvider.java
@@ -1,8 +1,10 @@
 package com.example.csdaily.security;
 
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -21,12 +23,27 @@ public class JwtTokenProvider {
         this.SECRET_KEY = Keys.hmacShaKeyFor(base64Secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(String userId) {
-        return Jwts.builder()
-                .setSubject(userId)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .signWith(SECRET_KEY, SignatureAlgorithm.HS256)
-                .compact();
-    }
+	public String generateToken(String userId) {
+		return Jwts.builder()
+			.setSubject(userId)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+			.signWith(SECRET_KEY, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public long getUserIdFromAccessToken(String accessToken) {
+		try {
+			String id = Jwts.parserBuilder()
+				.setSigningKey(SECRET_KEY)
+				.build()
+				.parseClaimsJws(accessToken)
+				.getBody()
+				.getSubject();
+			return Long.parseLong(id);
+		} catch (JwtException e) {
+			e.printStackTrace();
+		}
+		return 0L;
+	}
 }

--- a/src/main/java/com/example/csdaily/security/LoginUserArgumentResolver.java
+++ b/src/main/java/com/example/csdaily/security/LoginUserArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.example.csdaily.security;
+
+import java.util.Optional;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.example.csdaily.quiz.annotation.LoginUser;
+import com.example.csdaily.user.entity.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(LoginUser.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+		Optional<User> maybeUser = (Optional<User>)request.getAttribute("user");
+		return maybeUser.orElse(null);
+	}
+}


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #{issue_number}

## ✍️ 구현 내용
- JWT토큰을 사용하여 요청할 경우 토큰을 파싱하여 데이터베이스에 저장된 유저인지 검증합니다.
- 퀴즈 풀이 후 정답 여부만 보여줬던 DTO를 수정하여 각 선택지별 해설과 추가 개념, 결론을 보여주는 기능을 구현헀습니다.
## 📷 구현 영상
- 구현 영상을 업로드 해주세요.

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [ ] 관련 이슈 연결
- [ ] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
