### PR TITLE
[FIX] GPT API 호출 시 `response_format` 사용하도록 변경

### DIFF
--- a/src/main/java/com/example/csdaily/gpt/dto/request/QuizGenerationDto.java
+++ b/src/main/java/com/example/csdaily/gpt/dto/request/QuizGenerationDto.java
@@ -1,8 +1,0 @@
-package com.example.csdaily.gpt.dto.request;
-
-import java.util.List;
-
-import com.example.csdaily.gpt.dto.GPTMessageDto;
-
-public record QuizGenerationDto(String model, int n, List<GPTMessageDto> messages) {
-}

--- a/src/main/java/com/example/csdaily/gpt/service/QuizGenerationService.java
+++ b/src/main/java/com/example/csdaily/gpt/service/QuizGenerationService.java
@@ -6,13 +6,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import com.example.csdaily.gpt.dto.GPTMessageDto;
-import com.example.csdaily.gpt.dto.request.QuizGenerationDto;
 import com.example.csdaily.gpt.dto.response.GPTResponse;
 import com.example.csdaily.gpt.dto.response.GeneratedQuizDto;
 import com.example.csdaily.quiz.entity.Quiz;
@@ -31,8 +32,8 @@ public class QuizGenerationService {
 	private final QuizRepository quizRepository;
 	private final QuizChoiceRepository quizChoiceRepository;
 	private final ObjectMapper objectMapper;
+	private final HttpEntity<String> requestEntity;
 	private GPTResponse gptResponse;
-	private QuizGenerationDto quizGenerationDto;
 	private List<GeneratedQuizDto> generatedQuizDtos;
 	private List<Quiz> createdQuizzes;
 	private List<QuizChoice> createdQuizChoices;
@@ -40,20 +41,11 @@ public class QuizGenerationService {
 	@Value("${gpt.url}")
 	private String url;
 
-	@Value("${gpt.model}")
-	private String model;
-
-	@Value("${gpt.n}")
-	private int n;
-
 	@Value("${gpt.api-key}")
 	private String apiKey;
 
-	@Value("${gpt.prompt.developer}")
-	private String developerMessage;
-
-	@Value("${gpt.prompt.user}")
-	private String userMessage;
+	@Value("${gpt.prompt}")
+	private String prompt;
 
 	public QuizGenerationService(RestTemplate restTemplate, QuizRepository quizRepository,
 		QuizChoiceRepository quizChoiceRepository) {
@@ -62,10 +54,10 @@ public class QuizGenerationService {
 		this.quizChoiceRepository = quizChoiceRepository;
 		this.objectMapper = new ObjectMapper();
 
-		this.restTemplate.getInterceptors().add((request, body, execution) -> {
-			request.getHeaders().add("Authorization", "Bearer " + apiKey);
-			return execution.execute(request, body);
-		});
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.setBearerAuth(apiKey);
+		this.requestEntity = new HttpEntity<>(prompt, headers);
 	}
 
 	@Scheduled(cron = "0 0 * * * *")
@@ -92,16 +84,11 @@ public class QuizGenerationService {
 		generatedQuizDtos = null;
 		createdQuizzes = new ArrayList<>();
 		createdQuizChoices = new ArrayList<>();
-		if (quizGenerationDto == null) {
-			GPTMessageDto developerMessageDto = new GPTMessageDto("developer", developerMessage);
-			GPTMessageDto userMessageDto = new GPTMessageDto("user", userMessage);
-			quizGenerationDto = new QuizGenerationDto(model, n, List.of(developerMessageDto, userMessageDto));
-		}
 	}
 
 	private void sendRequest() {
 		try {
-			gptResponse = restTemplate.postForEntity(URI.create(url), quizGenerationDto, GPTResponse.class).getBody();
+			gptResponse = restTemplate.postForEntity(URI.create(url), requestEntity, GPTResponse.class).getBody();
 		} catch (RestClientException e) {
 			//todo: 에러 메세지 핸들링 필요.
 			log.error("GPT API 요청 실패!");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,9 +48,5 @@ kakao:
 
 gpt:
   url: https://api.openai.com/v1/chat/completions
-  model: ${OPENAI_API_MODEL}
-  n: ${OPENAI_API_N}
   api-key: ${OPENAI_API_KEY}
-  prompt:
-    developer: ${OPENAI_API_PROMPT_DEVELOPER}
-    user: ${OPENAI_API_PROMPT_USER}
+  prompt: ${OPENAI_API_PROMPT}


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #{issue_number}

## ✍️ 구현 내용
- 잘못된 프롬프트 사용으로 퀴즈 생성 시 500 에러가 나오던 오류를 수정했습니다.

## 📷 구현 영상
- 구현 영상을 업로드 해주세요.

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [ ] 관련 이슈 연결
- [ ] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
