### PR TITLE
[FIX] 의존성 주입 후에 requestEntity를 생성하도록 변경

### DIFF
--- a/src/main/java/com/example/csdaily/gpt/service/QuizGenerationService.java
+++ b/src/main/java/com/example/csdaily/gpt/service/QuizGenerationService.java
@@ -32,7 +32,7 @@ public class QuizGenerationService {
 	private final QuizRepository quizRepository;
 	private final QuizChoiceRepository quizChoiceRepository;
 	private final ObjectMapper objectMapper;
-	private final HttpEntity<String> requestEntity;
+	private HttpEntity<String> requestEntity;
 	private GPTResponse gptResponse;
 	private List<GeneratedQuizDto> generatedQuizDtos;
 	private List<Quiz> createdQuizzes;
@@ -53,11 +53,6 @@ public class QuizGenerationService {
 		this.quizRepository = quizRepository;
 		this.quizChoiceRepository = quizChoiceRepository;
 		this.objectMapper = new ObjectMapper();
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON);
-		headers.setBearerAuth(apiKey);
-		this.requestEntity = new HttpEntity<>(prompt, headers);
 	}
 
 	@Scheduled(cron = "0 0 * * * *")
@@ -84,6 +79,11 @@ public class QuizGenerationService {
 		generatedQuizDtos = null;
 		createdQuizzes = new ArrayList<>();
 		createdQuizChoices = new ArrayList<>();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.setBearerAuth(apiKey);
+		requestEntity = new HttpEntity<>(prompt, headers);
 	}
 
 	private void sendRequest() {


### PR DESCRIPTION
## 📮 관련 이슈
- resolved #{issue_number}

## ✍️ 구현 내용
- HttpEntity에 prompt를 담는 과정은 의존성 주입이 완료된 이후에 해야 제대로된 값이 prompt에 담겨지는데 그렇지 않았던 문제를 수정했습니다.

## 📷 구현 영상
- 구현 영상을 업로드 해주세요.

## ✔️ 확인 사항
- [x] 컨벤션에 맞는 PR 타이틀
- [ ] 관련 이슈 연결
- [ ] PR 관련 정보 연결 (작업자, 라벨, 마일스톤 등)
- [ ] Github Action 통과
